### PR TITLE
Read 05AB1E-encoded files as raw bytes, not UTF-8

### DIFF
--- a/05AB1E.py
+++ b/05AB1E.py
@@ -3905,7 +3905,7 @@ if __name__ == "__main__":
         code = EVAL
     # Do not load from file if just eval'ing
     elif ENCODE_OSABIE:
-        code = open(filename, "r", encoding="utf-8").read()
+        code = open(filename, "rb").read()
         code = osabie_to_utf8(code)
     else:
         code = open(filename, "r", encoding="utf-8").read()

--- a/lib/encoding.py
+++ b/lib/encoding.py
@@ -29,7 +29,7 @@ def osabie_to_utf8(code):
 
     # Replace the char with the corresponding character in the 05AB1E code page
     for char in code:
-        processed_code += osabie_code_page[ord(char)]
+        processed_code += osabie_code_page[char]
 
     return processed_code
 


### PR DESCRIPTION
When the -c/--osabie flag was passed, the interpreter was previously
reading the input file as UTF-8 anyway. Since the 05AB1E codepage
contains bytes that are invalid UTF-8, this fails for many programs.

Instead, it should read the file in binary mode rather than interpreting
what should be raw bytes under any kind of encoding.