### PR TITLE
Implement `.Ø` index-of-prime operator and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 inputs
 test.abe
 *.bat
+output_file
+temp_file

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -4,7 +4,7 @@ import fractions
 import ast
 import random
 from functools import reduce
-from itertools import count, takewhile
+from itertools import count
 
 letters = "abcdefghijklmnopqrstuvwxyz"
 numbers = "0123456789"
@@ -364,6 +364,7 @@ def get_nth_prime(n):
     return current_prime
 
 def get_index_of_prime(n):
+    from itertools import takewhile
     n = int(n)
     g = prime_sieve()
     return len(list(takewhile(lambda x: x <= n, g)))-1

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -4,7 +4,7 @@ import fractions
 import ast
 import random
 from functools import reduce
-from itertools import count
+from itertools import count, takewhile
 
 letters = "abcdefghijklmnopqrstuvwxyz"
 numbers = "0123456789"
@@ -363,6 +363,10 @@ def get_nth_prime(n):
             current_prime += 1
     return current_prime
 
+def get_index_of_prime(n):
+    n = int(n)
+    g = prime_sieve()
+    return len(list(takewhile(lambda x: x <= n, g)))-1
 
 def get_all_substrings(input_string):
     length = len(input_string)

--- a/osabie.py
+++ b/osabie.py
@@ -2528,6 +2528,14 @@ def run_program(commands,
                     a, lambda a: get_nth_prime(a), int
                 ))
 
+            elif current_command == ".\u00d8":
+                a = pop_stack(1)
+                stack.append(
+                    single_vectorized_evaluation(
+                        a, lambda a: get_index_of_prime(a), int
+                    )
+                )
+
             elif current_command == "\u00a2":
                 b = pop_stack(1)
                 a = pop_stack(1)

--- a/test/unit_tests/arithmetic.tests
+++ b/test/unit_tests/arithmetic.tests
@@ -303,6 +303,15 @@
 2Ø                  EXPECT `5`
 3Ø                  EXPECT `7`
 0 1 2 3)Ø           EXPECT `[2, 3, 5, 7]`
+0 1) 2 3)Ø          EXPECT `[[2, 3], 5, 7]`
+
+// Index of prime
+2.Ø                 EXPECT `0`
+3.Ø                 EXPECT `1`
+5.Ø                 EXPECT `2`
+7.Ø                 EXPECT `3`
+2 3) 5 7).Ø         EXPECT `[[0, 1], 2, 3]`
+2 3 5 7).Ø          EXPECT `[0, 1, 2, 3]`
 
 // Integer division
 8 4÷                EXPECT `2`


### PR DESCRIPTION
As I mentioned in #72, I'm new to the idioms of 05AB1E, but hopefully the tests are adequate.

My python is also quite rusty, so please do critique anything about the implementation.

Additionally, I noticed two files left behind after failed test runs; I added them to `.gitignore`.