### PR TITLE
Fix index errors from empty inputs

### DIFF
--- a/osabie.py
+++ b/osabie.py
@@ -62,6 +62,7 @@ def opt_input():
 
     try:
         a = input()
+
         if a[:3] == "\"\"\"":
             a = a[3:]
             while a[-3:] != "\"\"\"":
@@ -71,7 +72,10 @@ def opt_input():
 
         return a
     except:
-        return recent_inputs[-1]
+        try:
+            return recent_inputs[-1]
+        except:
+            return ""
 
 
 def is_array(array):

--- a/osabie.py
+++ b/osabie.py
@@ -62,7 +62,6 @@ def opt_input():
 
     try:
         a = input()
-
         if a[:3] == "\"\"\"":
             a = a[3:]
             while a[-3:] != "\"\"\"":


### PR DESCRIPTION
# Description

Fix `list index out of range` exceptions thrown when 05AB1E tries to implicitly fetch from a non-existent input.

This is done by catching that exception and returning an empty string, which seems to be the best possible approximation of an empty input.

# How to reproduce

```
$ wc -c ~/tmp/sandbox/inputs
0 /home/scottinet/tmp/sandbox/inputs
$ python3 osabie.py -d ~/tmp/sandbox/golf.abe < ~/tmp/sandbox/inputs 
Full program: 0«{γε¨g4÷¼}O¾<+3›
current >> 0  ||  stack: []
current >> «  ||  stack: ['0']
list index out of range
current >> {  ||  stack: []
list index out of range
...<snip>
```

# Use case

https://codegolf.stackexchange.com/questions/141581/can-i-settle-down/141660#141660


