### PR TITLE
Fix nested blocks detection

### DIFF
--- a/docs/md-documentation/loops.md
+++ b/docs/md-documentation/loops.md
@@ -132,11 +132,12 @@ Let's check it out: [Try it online!](https://tio.run/##MzBNTDJM/f9fKTEpOSU1Tams0
 | **`<code>`** | An 05AB1E code snippet |
 
 Loops until the counter variable reaches the provided `<num>` value.  
-Uses `N` as the _index variable_.
 
 The counter variable starts at 0, and can be modified using the following commands:
 
 - `¼`: increments the counter variable
 - `½`: pop a, and increments the counter variable if a is true (a == 1)
 
-**Tip:** 05AB1E automatically puts a `½` command at the end of the provided `<code>` if it doesn't contain a counter modifying command
+**Tips:** 
+* 05AB1E automatically puts a `½` command at the end of the provided `<code>` if it doesn't contain a counter modifying command
+

--- a/docs/md-documentation/loops.md
+++ b/docs/md-documentation/loops.md
@@ -138,6 +138,5 @@ The counter variable starts at 0, and can be modified using the following comman
 - `¼`: increments the counter variable
 - `½`: pop a, and increments the counter variable if a is true (a == 1)
 
-**Tips:** 
-* 05AB1E automatically puts a `½` command at the end of the provided `<code>` if it doesn't contain a counter modifying command
+**Tip:** 05AB1E automatically puts a `½` command at the end of the provided `<code>` if it doesn't contain a counter modifying command
 

--- a/docs/md-documentation/loops.md
+++ b/docs/md-documentation/loops.md
@@ -13,6 +13,7 @@ Loops are very important to repeat a specific command or a set of commands multi
  - [`ƒ`-loop](#ƒ-loop), ranges from **0** to **n**.
  - [`[`-loop](#-loop), ranges from **0** to **infinity**. Also known as an infinite loop.
  - [`v`-iterator](#v-iterator), iterates over each element
+ - [`µ`-loop](#µ-loop), loops until the counter value equals **n**
 
 --------------
 
@@ -117,3 +118,25 @@ For example, if we want to enumerate each character in the string `abcdef` and p
                     N,     #   Print the current index number with a newline
 
 Let's check it out: [Try it online!](https://tio.run/##MzBNTDJM/f9fKTEpOSU1Tams0l7JSkHJ3k/n/38A "05AB1E – Try It Online")
+
+-------------------
+
+## `µ`-loop
+
+- **Arity**: 1
+- **Syntax**: `<num> µ <code> }`
+
+| Parameter | Description |
+| --------- | ----------- |
+| **`<num>`** | An integer or a string representation of an integer |
+| **`<code>`** | An 05AB1E code snippet |
+
+Loops until the counter variable reaches the provided `<num>` value.  
+Uses `N` as the _index variable_.
+
+The counter variable starts at 0, and can be modified using the following commands:
+
+- `¼`: increments the counter variable
+- `½`: pop a, and increments the counter variable if a is true (a == 1)
+
+**Tip:** 05AB1E automatically puts a `½` command at the end of the provided `<code>` if it doesn't contain a counter modifying command

--- a/osabie.py
+++ b/osabie.py
@@ -620,7 +620,7 @@ def run_program(commands,
 
                 for Q in a:
                     stack.append(Q)
-                    run_program(statement, DEBUG, SAFE_MODE, True, range_variable, string_variable)
+                    run_program(statement, debug, safe_mode, True, range_variable, string_variable)
                     temp_list.append(stack[-1])
                     stack.clear()
 
@@ -818,10 +818,20 @@ def run_program(commands,
                 else_statement = ""
 
                 if '\u00eb' in statement:
-                    try:
-                        statement, else_statement = statement.split('\u00eb')
-                    except:
-                        pass
+                    else_count = 1
+                    pos = 0
+                    for c in statement:
+                        if c == '\u00eb':
+                            else_count -= 1
+                        elif c == 'i':
+                            else_count += 1
+
+                        if else_count == 0:
+                            break
+
+                        pos += 1
+                    else_statement = statement[pos+1:]
+                    statement = statement[0:pos]
 
                 if debug:
                     print("if: ", end="")
@@ -2068,7 +2078,7 @@ def run_program(commands,
                 for Q in zipper:
                     stack.append(Q[0])
                     stack.append(Q[1])
-                    run_program(for_each_command, DEBUG, SAFE_MODE, True,
+                    run_program(for_each_command, debug, safe_mode, True,
                                 range_variable, string_variable)
                 for Q in stack:
                     temp_list.append(Q)
@@ -2285,7 +2295,7 @@ def run_program(commands,
 
                 for Q in a:
                     stack.append(Q)
-                    run_program(statement, DEBUG, SAFE_MODE, True,
+                    run_program(statement, debug, safe_mode, True,
                                 range_variable, string_variable)
                     if not stack:
                         continue
@@ -2321,7 +2331,7 @@ def run_program(commands,
                 for Q in a:
                     is_queue.append(Q)
                     stack.append(Q)
-                    run_program(statement, DEBUG, SAFE_MODE, True,
+                    run_program(statement, debug, safe_mode, True,
                                 range_variable, string_variable)
                     temp_list.append([stack[-1] if stack else float('inf'), Q])
                     stack.clear()
@@ -3329,7 +3339,7 @@ def run_program(commands,
                     for_each_command += commands[pointer_position]
                 for Q in a:
                     stack.append(Q)
-                    run_program(for_each_command, DEBUG, SAFE_MODE, True,
+                    run_program(for_each_command, debug, safe_mode, True,
                                 range_variable, string_variable)
                 for Q in stack:
                     temp_list.append(Q)
@@ -3383,7 +3393,7 @@ def run_program(commands,
                             y = pop_stack(1)
                             stack.append(x)
                             stack.append(y)
-                        run_program(fold_command, DEBUG, SAFE_MODE, True,
+                        run_program(fold_command, debug, safe_mode, True,
                                     range_variable, string_variable)
                     b = pop_stack(1)
                     stack.clear()
@@ -3665,7 +3675,7 @@ def run_program(commands,
                         stack.clear()
                         stack.append(outer_element)
                         stack.append(inner_element)
-                        run_program(current_program, DEBUG, SAFE_MODE, True,
+                        run_program(current_program, debug, safe_mode, True,
                                     range_variable, string_variable)
                         inner_result.append(stack[-1])
                     result.append(inner_result)

--- a/osabie.py
+++ b/osabie.py
@@ -46,8 +46,8 @@ global_array = []
 is_queue = []
 previous_len = []
 
-# Looping commands:
-loop_commands = ["F", "i", "v", "G", "\u0192", "\u0292", "\u03A3"]
+# Block commands:
+block_commands = ["F", "i", "v", "G", "\u0192", "\u0292", "\u03A3", "\u03B5", "\u00b5"]
 
 # Global data
 
@@ -107,6 +107,33 @@ def get_input():
     recent_inputs.append(a)
     return a
 
+def get_block_statement(commands, pointer_position):
+    statement = ""
+    temp_position = pointer_position
+    temp_position += 1
+    current_command = commands[temp_position]
+    amount_brackets = 1
+    temp_string_mode = False
+    while amount_brackets != 0:
+        if current_command in "\"\u2018\u2019\u201C\u201D":
+            temp_string_mode = not temp_string_mode
+        if not temp_string_mode:
+            if current_command == "}":
+                amount_brackets -= 1
+                if amount_brackets == 0:
+                    break
+            elif current_command in block_commands:
+                amount_brackets += 1
+            statement += current_command
+        else:
+            statement += current_command
+        try:
+            temp_position += 1
+            current_command = commands[temp_position]
+        except:
+            break
+
+    return statement, temp_position
 
 def run_program(commands,
                 debug,
@@ -583,24 +610,17 @@ def run_program(commands,
                     temp_stack.append(Q)
                 stack.clear()
 
-                filter_code = ""
-                string_mode = False
-                while True:
+                statement, temp_position = get_block_statement(commands, pointer_position)
+
+                if debug:
                     try:
-                        pointer_position += 1
-                        if commands[pointer_position] in "\"\u2018\u2019\u201C\u201D":
-                            string_mode = not string_mode
-
-                        if commands[pointer_position] == "}" and not string_mode:
-                            break
-
-                        filter_code += commands[pointer_position]
+                        print("For each: {}".format(statement))
                     except:
-                        break
+                        pass
 
                 for Q in a:
                     stack.append(Q)
-                    run_program(filter_code, DEBUG, SAFE_MODE, True, range_variable, string_variable)
+                    run_program(statement, DEBUG, SAFE_MODE, True, range_variable, string_variable)
                     temp_list.append(stack[-1])
                     stack.clear()
 
@@ -608,6 +628,8 @@ def run_program(commands,
                 for Q in temp_stack:
                     stack.append(Q)
                 stack.append(temp_list)
+
+                pointer_position = temp_position
 
             elif current_command == "!":
                 a = pop_stack(1)
@@ -792,62 +814,26 @@ def run_program(commands,
                 stack.reverse()
 
             elif current_command == "i":
-                STATEMENT = ""
-                ELSE_STATEMENT = ""
-                elseify = False
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                amount_else = 1
-                temp_string_mode = False
-                temp_char_mode = False
+                statement, temp_position = get_block_statement(commands, pointer_position)
+                else_statement = ""
 
-                while amount_brackets != 0:
-                    if current_command in "\"\u2018\u2019\u201C\u201D":
-                        temp_string_mode = not temp_string_mode
-
-                    elif current_command == "'" and not temp_char_mode:
-                        temp_char_mode = True
-
-                    if temp_string_mode is False or temp_char_mode is False:
-                        if current_command in ["}", "\u00eb"]:
-                            if current_command == "}":
-                                amount_brackets -= 1
-                            elif current_command == "\u00eb":
-                                amount_else -= 1
-                                elseify = True
-                            if amount_brackets == 0:
-                                break
-                        elif current_command in loop_commands:
-                            amount_brackets += 1
-                            if current_command == "i":
-                                amount_else += 1
-
-                    temp_char_mode = True
-
-                    if not elseify:
-                        STATEMENT += current_command
-                    else:
-                        ELSE_STATEMENT += current_command
-
+                if '\u00eb' in statement:
                     try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
+                        statement, else_statement = statement.split('\u00eb')
                     except:
-                        break
+                        pass
 
                 if debug:
                     print("if: ", end="")
-                    for Q in STATEMENT:
+                    for Q in statement:
                         try:
                             print(Q, end="")
                         except:
                             print("?", end="")
                     print()
-                    if amount_else < 1:
+                    if else_statement:
                         print("else: ", end="")
-                        for Q in ELSE_STATEMENT:
+                        for Q in else_statement:
                             try:
                                 print(Q, end="")
                             except:
@@ -855,10 +841,10 @@ def run_program(commands,
                         print()
                 a = pop_stack(1)
                 if a == 1 or a == "1":
-                    run_program(STATEMENT, debug, safe_mode, True,
+                    run_program(statement, debug, safe_mode, True,
                                 range_variable, string_variable)
-                elif amount_else == 0:
-                    run_program(ELSE_STATEMENT[1:], debug, safe_mode, True,
+                elif else_statement:
+                    run_program(else_statement, debug, safe_mode, True,
                                 range_variable, string_variable)
                 pointer_position = temp_position
 
@@ -883,35 +869,14 @@ def run_program(commands,
                     stack.append(ast_int_eval(str(a)) * 2)
 
             elif current_command == "F":
-                STATEMENT = ""
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                temp_string_mode = False
-                while amount_brackets != 0:
-                    if current_command in "\"\u2018\u2019\u201C\u201D":
-                        temp_string_mode = not temp_string_mode
-                    if not temp_string_mode:
-                        if current_command == "}":
-                            amount_brackets -= 1
-                            if amount_brackets == 0:
-                                break
-                        elif current_command in loop_commands:
-                            amount_brackets += 1
-                        STATEMENT += current_command
-                    else:
-                        STATEMENT += current_command
-                    try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
-                    except:
-                        break
+                statement, temp_position = get_block_statement(commands, pointer_position)
+
                 if debug:
                     try:
-                        print(STATEMENT)
+                        print("Loop: {}".format(statement))
                     except:
                         pass
+
                 a = 0
                 if stack:
                     a = int(pop_stack(1))
@@ -921,38 +886,16 @@ def run_program(commands,
 
                 if a != 0:
                     for range_variable in range(0, a):
-                        run_program(STATEMENT, debug, safe_mode, True,
+                        run_program(statement, debug, safe_mode, True,
                                     range_variable, string_variable)
                 pointer_position = temp_position
 
             elif current_command == "G":
-                STATEMENT = ""
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                temp_string_mode = False
-                while amount_brackets != 0:
-                    if current_command in "\"\u2018\u2019\u201C\u201D":
-                        temp_string_mode = not temp_string_mode
-                    if not temp_string_mode:
-                        if current_command == "}":
-                            amount_brackets -= 1
-                            if amount_brackets == 0:
-                                break
-                        elif current_command in loop_commands:
-                            amount_brackets += 1
+                statement, temp_position = get_block_statement(commands, pointer_position)
 
-                    STATEMENT += current_command
-
-                    try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
-                    except:
-                        break
                 if debug:
                     try:
-                        print(STATEMENT)
+                        print("Loop: {}".format(statement))
                     except:
                         pass
                 a = 0
@@ -964,69 +907,30 @@ def run_program(commands,
 
                 if a > 1:
                     for range_variable in range(1, a):
-                        run_program(STATEMENT, debug, safe_mode, True,
+                        run_program(statement, debug, safe_mode, True,
                                     range_variable, string_variable)
                 pointer_position = temp_position
 
             elif current_command == "\u00b5":
-                STATEMENT = ""
-                ELSE_STATEMENT = ""
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                amount_else = 1
-                temp_string_mode = False
-                while amount_brackets != 0:
-                    if current_command in "\"\u2018\u2019\u201C\u201D":
-                        temp_string_mode = not temp_string_mode
-                    if not temp_string_mode:
-                        if current_command in ["}", "\u00eb"]:
-                            if current_command == "}":
-                                amount_brackets -= 1
-                            elif current_command == "\u00eb":
-                                amount_else -= 1
-                            if amount_brackets == 0:
-                                break
-                        elif current_command in loop_commands:
-                            amount_brackets += 1
-                            if current_command == "i":
-                                amount_else += 1
-                    if amount_else > 0:
-                        STATEMENT += current_command
-                    else:
-                        ELSE_STATEMENT += current_command
-                    try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
-                    except:
-                        break
+                statement, temp_position = get_block_statement(commands, pointer_position)
+
                 if debug:
-                    print("if: ", end="")
-                    for Q in STATEMENT:
-                        try:
-                            print(Q, end="")
-                        except:
-                            print("?", end="")
-                    print()
-                    if amount_else < 1:
-                        print("else: ", end="")
-                        for Q in ELSE_STATEMENT:
-                            try:
-                                print(Q, end="")
-                            except:
-                                print("?", end="")
-                        print()
+                    try:
+                        print("Loop: {}".format(statement))
+                    except:
+                        pass
+
                 a = pop_stack(1)
                 range_variable = 0
 
-                if '\u00bc' not in STATEMENT and '\u00bd' not in STATEMENT:
-                    STATEMENT = STATEMENT + '\u00bd'
+                if '\u00bc' not in statement and '\u00bd' not in statement:
+                    statement += '\u00bd'
 
                 while counter_variable[-1] != int(a):
                     range_variable += 1
-                    run_program(STATEMENT, debug, safe_mode, True,
+                    run_program(statement, debug, safe_mode, True,
                                 range_variable, string_variable)
+
                 pointer_position = temp_position
 
             elif current_command == "\u00cb":
@@ -1048,35 +952,14 @@ def run_program(commands,
                     stack.append(1 if all_equal else 0)
 
             elif current_command == "\u0192":
-                STATEMENT = ""
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                temp_string_mode = False
-                while amount_brackets != 0:
-                    if current_command in "\"\u2018\u2019\u201C\u201D":
-                        temp_string_mode = not temp_string_mode
-                    if not temp_string_mode:
-                        if current_command == "}":
-                            amount_brackets -= 1
-                            if amount_brackets == 0:
-                                break
-                        elif current_command in loop_commands:
-                            amount_brackets += 1
+                statement, temp_position = get_block_statement(commands, pointer_position)
 
-                    STATEMENT += current_command
-
-                    try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
-                    except:
-                        break
                 if debug:
                     try:
-                        print(STATEMENT)
+                        print("Loop: {}".format(statement))
                     except:
                         pass
+
                 a = 0
                 if stack:
                     a = int(pop_stack(1))
@@ -1086,7 +969,7 @@ def run_program(commands,
 
                 if a > -1:
                     for range_variable in range(0, a + 1):
-                        run_program(STATEMENT, debug, safe_mode, True,
+                        run_program(statement, debug, safe_mode, True,
                                     range_variable, string_variable)
                 pointer_position = temp_position
 
@@ -1817,37 +1700,14 @@ def run_program(commands,
                     stack.append(int(b in a))
 
             elif current_command == "v":
-                STATEMENT = ""
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                temp_string_mode = False
-                while amount_brackets != 0:
-                    if current_command in "\"\u2018\u2019\u201C\u201D":
-                        temp_string_mode = not temp_string_mode
-
-                    if not temp_string_mode:
-                        if current_command == "}":
-                            amount_brackets -= 1
-                        if amount_brackets == 0:
-                            break
-                        elif current_command in loop_commands:
-                            amount_brackets += 1
-
-                    STATEMENT += current_command
-
-                    try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
-                    except:
-                        break
+                statement, temp_position = get_block_statement(commands, pointer_position)
 
                 if debug:
                     try:
-                        print(STATEMENT)
+                        print("Loop: {}".format(statement))
                     except:
                         pass
+
                 a = 0
                 a = pop_stack(1)
 
@@ -1858,8 +1718,9 @@ def run_program(commands,
                     range_variable += 1
                     if debug:
                         print("N = " + str(range_variable))
-                    run_program(STATEMENT, debug, safe_mode, True,
+                    run_program(statement, debug, safe_mode, True,
                                 range_variable, string_variable)
+
                 pointer_position = temp_position
 
             elif current_command == "y":
@@ -2414,26 +2275,17 @@ def run_program(commands,
                     temp_stack.append(Q)
                 stack.clear()
 
-                filter_code = ""
-                string_mode = False
-                while True:
+                statement, temp_position = get_block_statement(commands, pointer_position)
+
+                if debug:
                     try:
-                        pointer_position += 1
-                        if commands[pointer_position]\
-                                in "\"\u2018\u2019\u201C\u201D":
-                            string_mode = not string_mode
-
-                        if commands[pointer_position] == "}"\
-                                and not string_mode:
-                            break
-
-                        filter_code += commands[pointer_position]
+                        print("Filter: {}".format(statement))
                     except:
-                        break
+                        pass
 
                 for Q in a:
                     stack.append(Q)
-                    run_program(filter_code, DEBUG, SAFE_MODE, True,
+                    run_program(statement, DEBUG, SAFE_MODE, True,
                                 range_variable, string_variable)
                     if not stack:
                         continue
@@ -2445,6 +2297,7 @@ def run_program(commands,
                 for Q in temp_stack:
                     stack.append(Q)
                 stack.append(temp_list)
+                pointer_position = temp_position
 
             elif current_command == "\u03A3":
                 a = pop_stack(1)
@@ -2457,27 +2310,18 @@ def run_program(commands,
                     temp_stack.append(Q)
                 stack.clear()
 
-                sort_code = ""
-                string_mode = False
-                while True:
+                statement, temp_position = get_block_statement(commands, pointer_position)
+
+                if debug:
                     try:
-                        pointer_position += 1
-                        if commands[pointer_position]\
-                                in "\"\u2018\u2019\u201C\u201D":
-                            string_mode = not string_mode
-
-                        if commands[pointer_position] == "}"\
-                                and not string_mode:
-                            break
-
-                        sort_code += commands[pointer_position]
+                        print("Sort with: {}".format(statement))
                     except:
-                        break
+                        pass
 
                 for Q in a:
                     is_queue.append(Q)
                     stack.append(Q)
-                    run_program(sort_code, DEBUG, SAFE_MODE, True,
+                    run_program(statement, DEBUG, SAFE_MODE, True,
                                 range_variable, string_variable)
                     temp_list.append([stack[-1] if stack else float('inf'), Q])
                     stack.clear()
@@ -2489,6 +2333,8 @@ def run_program(commands,
                     stack.append([x[1] for x in temp_list])
                 else:
                     stack.append(''.join([x[1] for x in temp_list]))
+
+                pointer_position = temp_position
 
             elif current_command == "\u203A":
                 b = pop_stack(1)

--- a/osabie.py
+++ b/osabie.py
@@ -818,15 +818,15 @@ def run_program(commands,
                 else_statement = ""
 
                 if '\u00eb' in statement:
-                    else_count = 1
+                    expected_else = 1
                     pos = 0
                     for c in statement:
                         if c == '\u00eb':
-                            else_count -= 1
+                            expected_else -= 1
                         elif c == 'i':
-                            else_count += 1
+                            expected_else += 1
 
-                        if else_count == 0:
+                        if expected_else == 0:
                             break
 
                         pos += 1

--- a/test/unit_tests/advanced.tests
+++ b/test/unit_tests/advanced.tests
@@ -7,3 +7,10 @@
 12345Sε5+                       EXPECT `[6, 7, 8, 9, 10]`
 12345SεD>«}ï                    EXPECT `[12, 23, 34, 45, 56]`
 123Sï456Sï)εε3+                 EXPECT `[[4, 5, 6], [7, 8, 9]]`
+
+// Nested loops
+3Ý3L)ʒvyÈ}O}        EXPECT `[[1, 2, 3]]`
+4L3Fε>}O)           EXPECT `[16]`
+
+// Nested ifs
+1i0ië1i42ë13        EXPECT `42`

--- a/test/unit_tests/advanced.tests
+++ b/test/unit_tests/advanced.tests
@@ -12,5 +12,6 @@
 3Ý3L)ʒvyÈ}O}        EXPECT `[[1, 2, 3]]`
 4L3Fε>}O)           EXPECT `[16]`
 
-// Nested ifs
+// Nested ifs / nested loops in ifs
 1i0ië1i42ë13        EXPECT `42`
+1i0i13ë2 4LFD·}Oë42 EXPECT `6`


### PR DESCRIPTION
# Description

Motivated by [this challenge](https://codegolf.stackexchange.com/questions/141949/count-edits-accounting-for-grace-period) I attempted this morning. I had a 12 bytes answer, tying with Jelly, but it didn't work as expected due to the bugs fixed in this PR :)

This PR fixes several problems with block statement extractions, by removing all specific block-detecting code in each command, using a unique `get_block_statement` to do the job. This should prevent inconsistencies across block commands due to different implementations, namely:

* `µ` and `ε` weren't considered as blocks by other block commands, causing parsing problems

Example: https://tio.run/##MzBNTDJM/f/f2M3E59xWP@1aFx0/nf///@umAAA

* #80

Example: https://tio.run/##MzBNTDJM/f//1KSyysMdtf61Ov//R0cb6CgY6igY6SgYx@ooREOZIF4sAA

This code should keep sublists with exactly 1 even number. Expected output:

`[[1, 2, 3, 3]]`

* ifs statement extraction fail for nested blocks commands

Example 1: nested ifs

https://tio.run/##MzBNTDJM/f/fMNMg8/Bqw0wTIyBp/P//f90UAA

(this example also contains 1 empty if and 1 if without else)

Expected output: `42`

Example 2: loop nested in nested-ifs

https://tio.run/##MzBNTDJM/f/fMNMg09D48GojBRMfN5dD22v9D682Mfr//79uCgA

Expected output: `6`

# Other changes

* Document the `µ` loop. This was motivated by me finding that 05AB1E automatically adds a `½` command if no counter modifying command is present, which is really nice :+1: 
* Fix wrong references to `DEBUG` and `SAFE_MODE` variables (wrong variable names, should be `debug` and `safe_mode` in the `run_program` function code)

# Notes

* If you know about other block-parsing problems, do not hesitate to test them against this branch
* Those are the first lines of Python I've ever written: be extra-careful when reviewing that code, and do not hesitate to criticize it.
