### PR TITLE
Make ']' an infinite close command

### DIFF
--- a/docs/info.txt
+++ b/docs/info.txt
@@ -92,7 +92,7 @@ Y	=            integer variable
 Z	=            push max(a) without popping
 [	=            infinite loop start
 \	=            delete last item
-]	=            infinite loop end
+]	=            close all loops and if statements
 ^	= pop a,b    push a XOR b
 _	= pop a      push negative bool
 `	= pop a      push all the items of a into the stack
@@ -124,7 +124,7 @@ y	=            push string variable (used in mapping loops)
 z	= pop a      push 1 / a
 {	= pop a      push sorted a
 |	=            push the rest of input as an array with strings
-}	=            used to close if statements, loops, etc.
+}	=            close a single if statement, loop, etc.
 ~	= pop a,b    push a OR b
 
 

--- a/osabie.py
+++ b/osabie.py
@@ -1210,9 +1210,11 @@ def run_program(commands,
 
                 if debug:
                     try:
-                        print("Loop: {}".format(statement))
+                        print("Infinite Loop: {}".format(statement))
                     except:
                         pass
+
+                range_variable = -1
 
                 while True:
                     range_variable += 1

--- a/osabie.py
+++ b/osabie.py
@@ -47,7 +47,7 @@ is_queue = []
 previous_len = []
 
 # Block commands:
-block_commands = ["F", "i", "v", "G", "\u0192", "\u0292", "\u03A3", "\u03B5", "\u00b5"]
+block_commands = ["F", "i", "v", "G", "[", "\u0192", "\u0292", "\u03A3", "\u03B5", "\u00b5"]
 
 # Global data
 
@@ -122,6 +122,9 @@ def get_block_statement(commands, pointer_position):
                 amount_brackets -= 1
                 if amount_brackets == 0:
                     break
+            elif current_command == "]":
+                amount_brackets = 0
+                break
             elif current_command in block_commands:
                 amount_brackets += 1
             statement += current_command
@@ -1203,32 +1206,20 @@ def run_program(commands,
                             stack.append(0)
 
             elif current_command == "[":
-                STATEMENT = ""
-                temp_position = pointer_position
-                temp_position += 1
-                current_command = commands[temp_position]
-                amount_brackets = 1
-                while amount_brackets != 0:
-                    if current_command == "]":
-                        amount_brackets -= 1
-                        if amount_brackets == 0:
-                            break
-                    elif current_command == "[":
-                        amount_brackets += 1
-                    STATEMENT += current_command
-                    try:
-                        temp_position += 1
-                        current_command = commands[temp_position]
-                    except:
-                        break
+                statement, temp_position = get_block_statement(commands, pointer_position)
+
                 if debug:
-                    print(STATEMENT)
-                range_variable = -1
+                    try:
+                        print("Loop: {}".format(statement))
+                    except:
+                        pass
+
                 while True:
                     range_variable += 1
-                    if run_program(STATEMENT, debug, safe_mode, True,
+                    if run_program(statement, debug, safe_mode, True,
                                    range_variable, string_variable):
                         break
+
                 pointer_position = temp_position
 
             elif current_command == "#":

--- a/test/unit_tests/advanced.tests
+++ b/test/unit_tests/advanced.tests
@@ -15,3 +15,6 @@
 // Nested ifs / nested loops in ifs
 1i0ië1i42ë13        EXPECT `42`
 1i0i13ë2 4LFD·}Oë42 EXPECT `6`
+
+// Infinite close
+9LvyÈiyDF>]O        EXPECT `40`

--- a/test/unit_tests/loops.tests
+++ b/test/unit_tests/loops.tests
@@ -2,7 +2,7 @@
 4FNO                EXPECT `6`
 
 // Infinite loop
-[NN45Q#]            EXPECT `45`
+[NN45Q#             EXPECT `45`
 
 // Counter variables
 ¼¼¼      ¾          EXPECT `3`


### PR DESCRIPTION
# Description

Change the behavior of `]` from "close an infinite loop" to "close all loops and if statements"
Infinite loops (`[`) can now be closed normally, either with `}`, `]`, or implicitly if at the end of a program.

Updated the documentation and added a test case

Related issue and discussion: #95 