### PR TITLE
Fix transliteration bug

### DIFF
--- a/lib/commands/str_commands.ex
+++ b/lib/commands/str_commands.ex
@@ -178,10 +178,30 @@ defmodule Commands.StrCommands do
         end)
     def to_codepoints(value), do: String.to_charlist(to_string(value))
 
-    def transliterate(string, from_chars, to_chars) when is_bitstring(string), do: Enum.join(transliterate(String.graphemes(to_string(string)), from_chars, to_chars), "")
-    def transliterate(list, from_chars, to_chars) when is_bitstring(from_chars) and is_bitstring(to_chars), do: transliterate(list, String.graphemes(from_chars), String.graphemes(to_chars))
-    def transliterate(list, from_chars, to_chars) when is_bitstring(from_chars), do: transliterate(list, String.graphemes(from_chars), to_chars)
-    def transliterate(list, from_chars, to_chars) when is_bitstring(to_chars), do: transliterate(list, from_chars, String.graphemes(to_chars))
+    @doc """
+    Transliterates the given string with the given transliteration set. For example, transliterating "abcd" with "bdg" → "qrs" would
+    transliterate the following in the initial string:
+
+     "b" → "q"
+     "d" → "r"
+     "g" → "s"
+
+    The first match in the transliteration set is the transliteration that is executed. Therefore "abcd" results in "aqcr" after transliteration.
+
+    ## Parameters
+
+     - string/list:     The string or list that needs to be transliterated.
+     - from_chars:      The from characters either as a single element or as a list.
+     - to_chars:        The characters to which the initial characters will be mapped to, either as a single element or a list.
+
+    ## Returns
+
+    The transliterated string or list depending on the initial type of the first parameter.
+    
+    """
+    def transliterate(string, from_chars, to_chars) when Functions.is_single?(string), do: Enum.join(transliterate(String.graphemes(to_string(string)), from_chars, to_chars), "")
+    def transliterate(list, from_chars, to_chars) when Functions.is_single?(from_chars), do: transliterate(list, String.graphemes(to_string(from_chars)), to_chars)
+    def transliterate(list, from_chars, to_chars) when Functions.is_single?(to_chars), do: transliterate(list, from_chars, String.graphemes(to_string(to_chars)))
     def transliterate(list, from_chars, to_chars) do
         transliteration_pairs = Stream.zip(from_chars, to_chars)
         list |> Stream.map(fn x ->

--- a/test/commands/ternary_test.exs
+++ b/test/commands/ternary_test.exs
@@ -5,12 +5,15 @@ defmodule TernaryTest do
     test "three swap" do
         assert evaluate("1 2 3Š)") == ["3", "1", "2"]
     end
-
+    
     test "transliterate" do
         assert evaluate("12345 23 78‡") == "17845"
         assert evaluate("12345 23S 78‡") == "17845"
         assert evaluate("12345 23 78S‡") == "17845"
         assert evaluate("12345 23S 78S‡") == "17845"
+        assert evaluate("12345ï 23S 78S‡") == "17845"
+        assert evaluate("12345 23ï 78‡") == "17845"
+        assert evaluate("12345 23 78ï‡") == "17845"
         assert evaluate("5L 23Sï 78Sï‡") == [1, 7, 8, 4, 5]
         assert evaluate("1 11 45‡") == "4"
         assert evaluate("10 20 30 40 50) ∞ ∞20+‡") == [30, 40, 50, 60, 70]


### PR DESCRIPTION
## Description

As [Kevin Cruijssen pointed out](https://chat.stackexchange.com/transcript/message/46778324#46778324), transliteration does not work properly when one of the parameters is an integer. This is now fixed by replacing `is_bitstring` with `is_single?` (which checks whether an element is a string or number) and always casts to a string if this is the case.

Tests are now also [added](https://github.com/Adriandmen/05AB1E/blob/209202cc318dd9f06d7241a2cabaf6c959672431/test/commands/ternary_test.exs#L14) to make sure that this does not happen again.