### PR TITLE
Fix index of multi-character strings in string

### DIFF
--- a/lib/commands/list_commands.ex
+++ b/lib/commands/list_commands.ex
@@ -254,14 +254,16 @@ defmodule Commands.ListCommands do
         list |> Stream.transform(nil, fn (x, acc) -> if GeneralCommands.equals(x, acc) do {[], acc} else {[x], x} end end) |> Stream.map(fn x -> x end)
     end
 
-    def index_in(value, element) do
-        cond do
-            Functions.is_iterable(value) -> 
-                case first_where(value |> Stream.with_index, fn {x, _} -> GeneralCommands.equals(x, element) end) do
-                    nil -> -1
-                    {_, index} -> index
-                end
-            true -> index_in(String.graphemes(to_string(value)), element)
+    def index_in(value, element) when Functions.is_single?(value) do
+        case :binary.match(to_string(value), to_string(element)) do
+            :nomatch -> -1
+            {index, _} -> index
+        end
+    end
+    def index_in(value, element) when Functions.is_iterable(value) do
+        case first_where(value |> Stream.with_index, fn {x, _} -> GeneralCommands.equals(x, element) end) do
+            nil -> -1
+            {_, index} -> index
         end
     end
 

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -317,6 +317,8 @@ defmodule BinaryTest do
     test "index in" do
         assert evaluate("1234 1k") == 0
         assert evaluate("1234 4k") == 3
+        assert evaluate("1234 23k") == 1
+        assert evaluate("1234 2345k") == -1
         assert evaluate("1234 14Sk") == [0, 3]
         assert evaluate("1234Sï 14Sïk") == [0, 3]
         assert evaluate("1234S 14Sïk") == [0, 3]


### PR DESCRIPTION
## Description

Retrieving the index of a string with a length larger than 1 [always results in -1](https://chat.stackexchange.com/transcript/message/46506319#46506319). This is now fixed by using the `:binary.match` method which retrieves can also retrieve the index of a multi-character string in a string.

Tests have been [added](https://github.com/Adriandmen/05AB1E/blob/b7269b9caeefec99d83f242efd9cd5bf257e50be/test/commands/binary_test.exs#L320) as well.