### PR TITLE
Fixed the E-loop

### DIFF
--- a/lib/interp/interpreter.ex
+++ b/lib/interp/interpreter.ex
@@ -579,11 +579,11 @@ defmodule Interp.Interpreter do
                 {new_stack, new_env} = GeneralCommands.loop(subcommands, stack, environment, 0, to_integer!(a) - 1)
                 {new_stack, %{new_env | range_variable: current_n}}
 
-            # For N in range [0, n]
+            # For N in range [1, n]
             "E" ->
                 {a, stack, environment} = Stack.pop(stack, environment)
                 current_n = environment.range_variable
-                {new_stack, new_env} = GeneralCommands.loop(subcommands, stack, environment, 0, to_integer!(a))
+                {new_stack, new_env} = GeneralCommands.loop(subcommands, stack, environment, 1, to_integer!(a))
                 {new_stack, %{new_env | range_variable: current_n}}
 
             # For N in range [1, n)

--- a/test/commands/special_test.exs
+++ b/test/commands/special_test.exs
@@ -21,8 +21,8 @@ defmodule SpecialOpsTest do
         assert evaluate("3F3FN} N})") == [0, 1, 2, 0, 0, 1, 2, 1, 0, 1, 2, 2]
     end
 
-    test "for loop [0, x]" do
-        assert evaluate("5EN})") == [0, 1, 2, 3, 4, 5]
+    test "for loop [1, N]" do
+        assert evaluate("5EN})") == [1, 2, 3, 4, 5]
     end
 
     test "for loop [1, N)" do


### PR DESCRIPTION
Until now, `ƒ` and `E` were exact synonyms, as [pointed out by Kevin Cruijssen](https://chat.stackexchange.com/transcript/message/46839878#46839878). `E` should have been **[1, n]** (or **(0, n]**) in the first place, not **[0, n]**, which is already covered by the other aforementioned command.