### PR TITLE
Fix sort by

### DIFF
--- a/lib/interp/interpreter.ex
+++ b/lib/interp/interpreter.ex
@@ -659,7 +659,7 @@ defmodule Interp.Interpreter do
                         |> Stream.transform(environment, fn ({x, index}, curr_env) ->
                             {result_stack, new_env} = interp(subcommands, %Stack{elements: [x]}, %{curr_env | range_variable: index, range_element: x})
                             {result, _, new_env} = Stack.pop(result_stack, new_env)
-                            {[{result, x}], new_env} end)
+                            {[{eval(result), x}], new_env} end)
                         |> Enum.sort_by(fn {a, _} -> a end)
                         |> Stream.map(fn {_, x} -> x end)
                 {Stack.push(stack, result), environment}

--- a/test/commands/special_test.exs
+++ b/test/commands/special_test.exs
@@ -53,6 +53,7 @@ defmodule SpecialOpsTest do
     test "sort by program" do
         assert evaluate("5LΣÈ") == [1, 3, 5, 2, 4]
         assert evaluate("12345 123 123456789) Σg") == ["123", "12345", "123456789"]
+        assert evaluate("123Sï Σε132sk") == [1, 3, 2]
     end
 
     test "run until no change" do


### PR DESCRIPTION
## Description

The sort by function breaks when sorting unevaluated elements with each other (e.g. streams). Values are now evaluated when transformed:

https://github.com/Adriandmen/05AB1E/blob/a3b67f6bcf871e7212c06452158a0706ce236c03/lib/interp/interpreter.ex#L657-L664

Added the example [Emigna gave](https://chat.stackexchange.com/transcript/message/46919028#46919028) as an additional test:

https://github.com/Adriandmen/05AB1E/blob/a3b67f6bcf871e7212c06452158a0706ce236c03/test/commands/special_test.exs#L56

