### PR TITLE
Fix stack rotation

### DIFF
--- a/lib/interp/interpreter.ex
+++ b/lib/interp/interpreter.ex
@@ -109,8 +109,8 @@ defmodule Interp.Interpreter do
             "žƵ" -> Stack.push(stack, "https://www.")
             "žÀ" -> Stack.push(stack, "aeiouAEIOU")
             "žÁ" -> Stack.push(stack, "aeiouyAEIOUY")
-            ".À" -> %Stack{elements: ListCommands.rotate(stack.elements, -1)}
-            ".Á" -> %Stack{elements: ListCommands.rotate(stack.elements, 1)}
+            ".À" -> %Stack{elements: ListCommands.rotate(stack.elements, -1) |> Enum.to_list}
+            ".Á" -> %Stack{elements: ListCommands.rotate(stack.elements, 1) |> Enum.to_list}
             ".g" -> Stack.push(stack, GeneralCommands.length_of(stack.elements))
         end
 

--- a/lib/osabie.ex
+++ b/lib/osabie.ex
@@ -49,7 +49,7 @@ defmodule Osabie.CLI do
 
         # Set the debug parameters to the global environment
         if parsed_args.debug.enabled do
-            Globals.set(%{Globals.get() | debug: parsed_args.debug})            
+            Globals.set(%{Globals.get() | debug: parsed_args.debug})
         end
 
         # Run the code and retrieve the last element of the stack


### PR DESCRIPTION
## Description

As Emigna [pointed out](https://chat.stackexchange.com/transcript/message/47023139#47023139), stack rotation throws exceptions because the rotated version of the stack is not casted explicitly to a list. This is now done using the `Enum.to_list` function.