### PR TITLE
Fix no op bugs

### DIFF
--- a/lib/interp/interpreter.ex
+++ b/lib/interp/interpreter.ex
@@ -965,7 +965,7 @@ defmodule Interp.Interpreter do
                     {:if_statement, if_statement, else_statement} -> interp_if_statement(if_statement, else_statement, stack, environment)
                     {:no_op, _} -> {stack, environment}
                     {:eof, _} -> {stack, environment}
-                    x -> IO.inspect x
+                    _ -> {stack, environment}
                 end
                 interp(remaining, new_stack, new_env)
             :break -> {stack, environment}


### PR DESCRIPTION
## Description

Unmatched brackets like `}` did not return a stack and environment variable which makes the interpreter run into an error. Invalid tokens just return the stack and environment variable and leave them untouched.