### PR TITLE
Fix indexing in Unicode strings

### DIFF
--- a/lib/commands/list_commands.ex
+++ b/lib/commands/list_commands.ex
@@ -255,9 +255,9 @@ defmodule Commands.ListCommands do
     end
 
     def index_in(value, element) when Functions.is_single?(value) do
-        case :binary.match(to_string(value), to_string(element)) do
-            :nomatch -> -1
-            {index, _} -> index
+        case String.split(to_string(value), to_string(element), parts: 2) do
+            [left, _] -> String.length(left)
+            [_] -> -1
         end
     end
     def index_in(value, element) when Functions.is_iterable(value) do

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -332,6 +332,7 @@ defmodule BinaryTest do
         assert evaluate("1234S 5k") == -1
         assert evaluate("1234S 54Sk") == [-1, 3]
         assert evaluate("∞ 5k") == 4
+        assert evaluate("\"ƵƵÅ\"'Åk") == 2
     end
 
     test "list multiply" do


### PR DESCRIPTION
## Description

Indexing of substrings in strings containing Unicode strings did not work properly, because the codepoints of the characters were considered rather than the actual graphemes. This is now fixed by replacing the `:binary.match/2` method with the `String.split/3` method.