### PR TITLE
Fix take first bug when taking 0 elements

### DIFF
--- a/lib/commands/list_commands.ex
+++ b/lib/commands/list_commands.ex
@@ -66,6 +66,8 @@ defmodule Commands.ListCommands do
 
     def take_first(value, count) do
         cond do
+            count == 0 and Functions.is_iterable(value) -> []
+            count == 0 -> ""
             Functions.is_iterable(count) -> take_split(value, count)
             Functions.is_iterable(value) -> Stream.take(value, Functions.to_number(count))
             true -> String.slice(to_string(value), 0..count - 1)

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -142,6 +142,8 @@ defmodule BinaryTest do
         assert evaluate("123456 1224S£") == ["1", "23", "45", "6"]
         assert evaluate("∞ 1234S£") == [[1], [2, 3], [4, 5, 6], [7, 8, 9, 10]]
         assert evaluate("∞∞£4£") == [[1], [2, 3], [4, 5, 6], [7, 8, 9, 10]]
+        assert evaluate("123456 0£") == ""
+        assert evaluate("5L 0£") == []
     end
 
     test "modulo" do


### PR DESCRIPTION
## Description

When taking 0 elements from a string or list (using the `£` command), the interpreter would error and return the left argument. Now, these edge cases are added in the `take_first` function:

https://github.com/Adriandmen/05AB1E/blob/7d992e98547e17af237a6565e8b4e3e3c9225070/lib/commands/list_commands.ex#L67-L75