### PR TITLE
Fix decimal argument to integer parsing bug in list multiplication

### DIFF
--- a/lib/interp/interpreter.ex
+++ b/lib/interp/interpreter.ex
@@ -341,7 +341,7 @@ defmodule Interp.Interpreter do
             "Ö" -> Stack.push(stack, call_binary(fn x, y -> to_number(IntCommands.mod(to_number(x), to_number(y)) == 0) end, a, b))
             "ù" -> Stack.push(stack, call_binary(fn x, y -> ListCommands.keep_with_length(x, to_integer!(y)) end, a, b, true, false))
             "k" -> Stack.push(stack, call_binary(fn x, y -> ListCommands.index_in(x, y) end, a, b, true, false))
-            "и" -> Stack.push(stack, call_binary(fn x, y -> ListCommands.list_multiply(x, to_number(y)) end, a, b, true, false))
+            "и" -> Stack.push(stack, call_binary(fn x, y -> ListCommands.list_multiply(x, to_integer(y)) end, a, b, true, false))
             "¢" -> Stack.push(stack, call_binary(fn x, y -> GeneralCommands.count(x, y) end, a, b, true, false))
             "×" -> Stack.push(stack, call_binary(fn x, y -> String.duplicate(to_string(x), to_integer!(y)) end, a, b))
             "в" -> Stack.push(stack, call_binary(fn x, y -> IntCommands.to_base_arbitrary(to_integer!(x), to_integer!(y)) end, a, b))

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -342,6 +342,7 @@ defmodule BinaryTest do
         assert evaluate("3L 3и") == [1, 2, 3, 1, 2, 3, 1, 2, 3]
         assert evaluate("3L 0и") == []
         assert evaluate("3L 123Sи") == [[1, 2, 3], [1, 2, 3, 1, 2, 3], [1, 2, 3, 1, 2, 3, 1, 2, 3]]
+        assert evaluate("3L 3.0и") == [1, 2, 3, 1, 2, 3, 1, 2, 3]
     end
 
     test "extract each nth" do


### PR DESCRIPTION
## Description

Previously, when performing list multiplication, decimal numbers were not converted to integers which made the command run into a invalid type error. For example:

    [1, 2, 3] 3.0 и

This should give `[1, 2, 3, 1, 2, 3, 1, 2, 3]`, but runs into an exception. Fixed by replacing `to_number` with `to_integer`:

https://github.com/Adriandmen/05AB1E/blob/4987160f840c6750db882badcabfe84cdd33a019/lib/interp/interpreter.ex#L344

