### PR TITLE
Add 'first n'-flag for the recursive list generation command

### DIFF
--- a/lib/interp/commands/subprogram_interp.ex
+++ b/lib/interp/commands/subprogram_interp.ex
@@ -200,6 +200,7 @@ defmodule Interp.SubprogramInterp do
 
                 {flag, subcommands} = case subcommands do
                     [{_, "j"} | remaining] -> {:contains, remaining}
+                    [{_, "£"} | remaining] -> {:first_n, remaining}
                     _ -> {:normal, subcommands}
                 end
                 
@@ -210,6 +211,9 @@ defmodule Interp.SubprogramInterp do
                     :contains -> 
                         {b, stack, environment} = Stack.pop(stack, environment)
                         {Stack.push(stack, to_number(ListCommands.increasing_contains(result, to_number(b)))), environment}
+                    :first_n ->
+                        {b, stack, environment} = Stack.pop(stack, environment)
+                        {Stack.push(stack, ListCommands.take_first(result, to_integer(b))), environment}
                 end
 
             # Group by function

--- a/test/commands/special_test.exs
+++ b/test/commands/special_test.exs
@@ -211,6 +211,11 @@ defmodule SpecialOpsTest do
         assert evaluate("37 1λj+") == 0
     end
 
+    test "recursive list with first n flag" do
+        assert evaluate("5 1λ£+") == [1, 1, 2, 3, 5]
+        assert evaluate("234S 1λ£+") == [[1, 1], [2, 3, 5], [8, 13, 21, 34]]
+    end
+
     test "group by function" do
         assert evaluate("5L.γ4‹") == [[1, 2, 3], [4, 5]]
         assert evaluate("12345.γ4‹") == ["123", "45"]


### PR DESCRIPTION
## Description

Adds the 'first n'-flag as `£` for the recursive list generation command. Usage:

    5 1λ£+

Which acts the same as `5 1λ+}s£`.