### PR TITLE
Fix the negative number to base conversion bug

### DIFF
--- a/lib/commands/int_commands.ex
+++ b/lib/commands/int_commands.ex
@@ -144,6 +144,7 @@ defmodule Commands.IntCommands do
     Converts the given number to the given base and returns it as a string using the characters
     from the 05AB1E code page, except for '•', which is used to decompress base-255 strings.
     """
+    def to_base(value, base) when value < 0, do: "-" <> to_base(-value, base)
     def to_base(value, base) do
         Integer.digits(value, base) |> Enum.map(fn x -> Enum.at(digits(), x) end) |> List.to_string
     end

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -64,6 +64,8 @@ defmodule BinaryTest do
     test "convert to base" do
         assert evaluate("55 2B") == "110111"
         assert evaluate("5545646 47B") == "16JMM"
+        assert evaluate("11 12B") == "B"
+        assert evaluate("11(12B") == "-B"
     end
 
     test "string subtraction" do


### PR DESCRIPTION
## Description

Converting negative numbers did not work properly, e.g. `11( 12B`  should result in `-B`.

Fixed by concatenating a `-` before the result of converting the positive number to that base.