### PR TITLE
Fix take first bug with negative integers on iterable values

### DIFF
--- a/lib/commands/list_commands.ex
+++ b/lib/commands/list_commands.ex
@@ -69,7 +69,8 @@ defmodule Commands.ListCommands do
             count == 0 and Functions.is_iterable(value) -> []
             count == 0 -> ""
             Functions.is_iterable(count) -> take_split(value, count)
-            Functions.is_iterable(value) -> Stream.take(value, Functions.to_number(count))
+            Functions.is_iterable(value) and count < 0 -> Stream.take(value, length(Enum.to_list(value)) + count) |> Stream.map(fn x -> x end)
+            Functions.is_iterable(value) -> Stream.take(value, Functions.to_number(count)) |> Stream.map(fn x -> x end)
             true -> String.slice(to_string(value), 0..count - 1)
         end
     end

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -146,6 +146,8 @@ defmodule BinaryTest do
         assert evaluate("∞∞£4£") == [[1], [2, 3], [4, 5, 6], [7, 8, 9, 10]]
         assert evaluate("123456 0£") == ""
         assert evaluate("5L 0£") == []
+        assert evaluate("TL3(£") == [1, 2, 3, 4, 5, 6, 7]
+        assert evaluate("\"abcdefghij\"3(£") == "abcdefg"
     end
 
     test "modulo" do


### PR DESCRIPTION
## Description

Fixes the 'take-first'-bug (`£`) on iterables with negative values.