### PR TITLE
Fix run while bug

### DIFF
--- a/lib/commands/gen_commands.ex
+++ b/lib/commands/gen_commands.ex
@@ -9,6 +9,7 @@ defmodule Commands.GeneralCommands do
     alias Interp.RecursiveEnvironment
     alias HTTPoison
     alias Commands.ListCommands
+    alias Commands.GeneralCommands
     require Interp.Functions
     
     def head(value) do
@@ -173,8 +174,8 @@ defmodule Commands.GeneralCommands do
         {result_stack, new_env} = Interpreter.interp(commands, %Stack{elements: [prev_result]}, %{environment | range_variable: index, range_element: prev_result})
         {result, _, new_env} = Stack.pop(result_stack, new_env)
         cond do
-            result == prev_result and prev_results == nil -> {result, new_env}
-            result == prev_result -> {prev_results |> Enum.reverse, new_env}
+            GeneralCommands.equals(prev_result, result) and prev_results == nil -> {result, new_env}
+            GeneralCommands.equals(prev_result, result) -> {prev_results |> Enum.reverse, new_env}
             prev_results == nil -> run_while(result, commands, new_env, index + 1)
             true -> run_while(result, commands, new_env, index + 1, [result | prev_results])
         end


### PR DESCRIPTION
As noted by KevinCruijssen, the **run-while** command (`Δ`) sometimes runs into an infinite loop. This was caused by the fact that this command did not use the overridden 'equals'-method (`GeneralCommands.equal/2`):

https://github.com/Adriandmen/05AB1E/blob/fc411e5ae9c73db4030cd47deb37ebd429299e32/lib/commands/gen_commands.ex#L177-L178