### PR TITLE
New flag – infinite list generation (n-th element)

### DIFF
--- a/lib/interp/commands/subprogram_interp.ex
+++ b/lib/interp/commands/subprogram_interp.ex
@@ -215,6 +215,7 @@ defmodule Interp.SubprogramInterp do
                 {flag, subcommands} = case subcommands do
                     [{_, "j"} | remaining] -> {:contains, remaining}
                     [{_, "£"} | remaining] -> {:first_n, remaining}
+                    [{_, "è"} | remaining] -> {:at_n, remaining}
                     _ -> {:normal, subcommands}
                 end
                 
@@ -228,6 +229,9 @@ defmodule Interp.SubprogramInterp do
                     :first_n ->
                         {b, stack, environment} = Stack.pop(stack, environment)
                         {Stack.push(stack, ListCommands.take_first(result, to_integer(b))), environment}
+                    :at_n ->
+                        {b, stack, environment} = Stack.pop(stack, environment)
+                        {Stack.push(stack, GeneralCommands.element_at(result, to_integer(b))), environment}
                 end
 
             # Group by function

--- a/test/commands/special_test.exs
+++ b/test/commands/special_test.exs
@@ -215,6 +215,10 @@ defmodule SpecialOpsTest do
         assert evaluate("5 1λ£+") == [1, 1, 2, 3, 5]
         assert evaluate("234S 1λ£+") == [[1, 1], [2, 3, 5], [8, 13, 21, 34]]
     end
+    
+    test "recursive list with n-th flag" do
+        assert evaluate("4 1λè+") == 5
+    end
 
     test "group by function" do
         assert evaluate("5L.γ4‹") == [[1, 2, 3], [4, 5]]


### PR DESCRIPTION
Added the `è` flag to `λ`, which given **n**, retrieves the **n**-th element, 0-indexed (such that the behaviour matches that of `e` as a command).

We [have discussed](https://chat.stackexchange.com/transcript/message/46253555#46253555) about adding this flag a while ago but I think the idea has been forgotten since. 

<s>To-do: add tests.</s>