### PR TITLE
Fix the infinite cycling bug when indexing on an empty list

### DIFF
--- a/lib/commands/gen_commands.ex
+++ b/lib/commands/gen_commands.ex
@@ -38,7 +38,8 @@ defmodule Commands.GeneralCommands do
 
     def detail(value) do
         cond do
-            Functions.is_iterable(value) -> Stream.take(value, length(Enum.to_list(value)) - 1) |> Stream.map(fn x -> x end)
+            Functions.is_iterable(value) -> 
+                value |> Enum.reverse |> tl |> Enum.reverse |> Stream.map(fn x -> x end)
             true -> String.slice(to_string(value), 0..-2)
         end
     end
@@ -46,7 +47,11 @@ defmodule Commands.GeneralCommands do
     def element_at(value, index) when index < 0, do: element_at(value, IntCommands.mod(index, length_of(value)))
     def element_at(value, index) do
         case value |> Stream.drop(index) |> Stream.take(1) |> Enum.to_list |> List.first do
-            nil -> Stream.cycle(value) |> Stream.drop(index) |> Stream.take(1) |> Enum.to_list |> List.first
+            nil -> 
+                cond do
+                    value |> length_of() == 0 -> value
+                    true -> Stream.cycle(value) |> Stream.drop(index) |> Stream.take(1) |> Enum.to_list |> List.first
+                end
             head -> head
         end
     end

--- a/test/commands/binary_test.exs
+++ b/test/commands/binary_test.exs
@@ -16,6 +16,7 @@ defmodule BinaryTest do
 
         assert evaluate("123456789 3(è") == "7"
         assert evaluate("TL®è") == 10
+        assert evaluate("1L¨0è") == []
     end
 
     test "addition" do

--- a/test/commands/unary_test.exs
+++ b/test/commands/unary_test.exs
@@ -246,6 +246,8 @@ defmodule UnaryTest do
         assert evaluate("\"\"¨") == ""
         assert evaluate("12345ï¨") == "1234"
         assert evaluate("5L¨") == [1, 2, 3, 4]
+        assert evaluate("1L¨") == []
+        assert evaluate("1L¨¨") == []
     end
 
     test "deltas" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,5 @@
-# Timeout is currently configured to 300ms for a single set of tests.
-ExUnit.start(timeout: 300)
+# Timeout is currently configured to 2000ms for a single set of tests.
+ExUnit.start(timeout: 2000)
 
 defmodule TestHelper do
     use ExUnit.Case

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
-ExUnit.start()
+# Timeout is currently configured to 300ms for a single set of tests.
+ExUnit.start(timeout: 300)
 
 defmodule TestHelper do
     use ExUnit.Case


### PR DESCRIPTION
## Description

Occasionally when a list is indexed, the list gets cycled and indexed afterward when the index surpasses the length of the list. This however ends up in an infinite cycle when the list is empty. To fix this, a simple check whether the list is empty or not is added.