### PR TITLE
Fix the 'is-integer' command

### DIFF
--- a/lib/interp/commands/unary_interp.ex
+++ b/lib/interp/commands/unary_interp.ex
@@ -75,7 +75,7 @@ defmodule Interp.UnaryInterp do
            ".l" -> Stack.push(stack, call_unary(fn x -> to_number Regex.match?(~r/^[a-z]+$/, to_string(x)) end, a))
            ".u" -> Stack.push(stack, call_unary(fn x -> to_number Regex.match?(~r/^[A-Z]+$/, to_string(x)) end, a))
            ".p" -> Stack.push(stack, call_unary(fn x -> ListCommands.prefixes(x) end, a, true))
-           ".ï" -> Stack.push(stack, call_unary(fn x -> to_number(to_number(x) == to_integer(x)) end, a))
+           ".ï" -> Stack.push(stack, call_unary(fn x -> to_number(is_integer?(x)) end, a))
            ".²" -> Stack.push(stack, call_unary(fn x -> :math.log2(to_number(x)) end, a))
            ".E" -> Stack.push(stack, call_unary(fn x -> {result, _} = Code.eval_string(to_string(x)); result end, a))
            ".Ø" -> Stack.push(stack, call_unary(fn x -> IntCommands.get_prime_index(to_number(x)) end, a))

--- a/lib/interp/commands/unary_interp.ex
+++ b/lib/interp/commands/unary_interp.ex
@@ -75,7 +75,7 @@ defmodule Interp.UnaryInterp do
            ".l" -> Stack.push(stack, call_unary(fn x -> to_number Regex.match?(~r/^[a-z]+$/, to_string(x)) end, a))
            ".u" -> Stack.push(stack, call_unary(fn x -> to_number Regex.match?(~r/^[A-Z]+$/, to_string(x)) end, a))
            ".p" -> Stack.push(stack, call_unary(fn x -> ListCommands.prefixes(x) end, a, true))
-           ".ï" -> Stack.push(stack, call_unary(fn x -> to_number(is_integer(to_number(x))) end, a))
+           ".ï" -> Stack.push(stack, call_unary(fn x -> to_number(to_number(x) == to_integer(x)) end, a))
            ".²" -> Stack.push(stack, call_unary(fn x -> :math.log2(to_number(x)) end, a))
            ".E" -> Stack.push(stack, call_unary(fn x -> {result, _} = Code.eval_string(to_string(x)); result end, a))
            ".Ø" -> Stack.push(stack, call_unary(fn x -> IntCommands.get_prime_index(to_number(x)) end, a))

--- a/lib/interp/functions.ex
+++ b/lib/interp/functions.ex
@@ -103,7 +103,7 @@ defmodule Interp.Functions do
         end
     end
 
-    def is_integer?(value), do: (try do is_integer(to_number(value)) catch _ -> false end)
+    def is_integer?(value), do: (to_number(value) == to_integer(value) and not(is_bitstring(to_number(value))))
     def is_number?(value), do: (try do is_number(to_number(value)) catch _ -> false end)
 
     def to_non_number(value) do

--- a/test/commands/unary_test.exs
+++ b/test/commands/unary_test.exs
@@ -706,6 +706,7 @@ defmodule UnaryTest do
         assert evaluate("4(.ï") == 1
         assert evaluate("4.5.ï") == 0
         assert evaluate("4.0.ï") == 1
+        assert evaluate("3 3.0) 1/ .ï") == [1, 1]
     end
     
     test "log 2" do

--- a/test/commands/unary_test.exs
+++ b/test/commands/unary_test.exs
@@ -707,6 +707,7 @@ defmodule UnaryTest do
         assert evaluate("4.5.ï") == 0
         assert evaluate("4.0.ï") == 1
         assert evaluate("3 3.0) 1/ .ï") == [1, 1]
+        assert evaluate("3ï 3 1/ 3 2/ 1.5) .ï") == [1, 1, 0, 0]
     end
     
     test "log 2" do

--- a/test/commands/unary_test.exs
+++ b/test/commands/unary_test.exs
@@ -708,6 +708,7 @@ defmodule UnaryTest do
         assert evaluate("4.0.ï") == 1
         assert evaluate("3 3.0) 1/ .ï") == [1, 1]
         assert evaluate("3ï 3 1/ 3 2/ 1.5) .ï") == [1, 1, 0, 0]
+        assert evaluate("'a .ï") == 0
     end
     
     test "log 2" do


### PR DESCRIPTION
## Description

The 'is-integer' command (aka `.ï`) checks whether a number can be represented as an integer. The baseline rule to know when a number **_`n`_** is an integer in 05AB1E is when <code><b><i>n</i></b> mod 1 ≡ 0</code>. For example, the following values should return true:

 - `4`
 - `"4"`
 - `4.0`
 - `"4.0"`

And the following should return false:

 - `4.3`
 - `"4.3"`
 - `"a"`

This is now performed by checking when:

```
to_number(value) == to_integer(value) and not(is_bitstring(to_number(value)))
```

